### PR TITLE
Show next income countdown

### DIFF
--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -170,6 +170,13 @@ func (game *Game) Update(delta float64) []*ServerEvent {
 			events = append(events, updateEvent(field.Player, field.ID))
 		}
 		game.IncomeCooldown = float64(game.Config.IncomeCooldown)
+		// notify clients about new income cooldown
+		events = append(events, &ServerEvent{
+			Type:    "incomeCooldown",
+			Kind:    "update",
+			FieldID: -1,
+			Payload: game.IncomeCooldown,
+		})
 	}
 
 	game.Elapsed += delta

--- a/web/client/src/game/GameClient.ts
+++ b/web/client/src/game/GameClient.ts
@@ -41,6 +41,8 @@ export type FieldChangeAction =
     | { type: "barracks"; kind: GameChangeActionDeleteKind; fieldId: number; barracksId: number }
     // Path actions
     | { type: "path"; kind: GameChangeActionChangeKind; fieldId: number; path: GridCoordinate[] }
+    // Income cooldown update
+    | { type: "incomeCooldown"; incomeCooldown: number }
 
 export type FieldUpdateDispatch = (action: FieldChangeAction, gameClient: GameClient) => void;
 
@@ -332,6 +334,9 @@ export default class GameClient {
             case "path":
                 if (eventKind === "create" || eventKind === "update")
                     this.dispatch({ type: 'path', kind: eventKind, fieldId, path: eventPayload });
+                break;
+            case "incomeCooldown":
+                this.dispatch({ type: 'incomeCooldown', incomeCooldown: eventPayload });
                 break;
             default:
                 console.log("Unknown event type:", eventType, event);

--- a/web/client/src/hooks/useUiState.tsx
+++ b/web/client/src/hooks/useUiState.tsx
@@ -26,6 +26,7 @@ export type UiStateContextAction =
     | { type: "set-field"; field: FieldModel }
 
     | { type: "set-path"; path: { x: number, y: number }[] }
+    | { type: "set-incomeCooldown"; incomeCooldown: number }
 
 function reducer(state: InitialUiState | undefined, action: UiStateContextAction): InitialUiState | undefined {
     if (action.type === 'set-uiState')
@@ -111,6 +112,18 @@ function reducer(state: InitialUiState | undefined, action: UiStateContextAction
                 selectedTower: action.selectedTower,
             }
         }
+        case 'set-incomeCooldown': {
+            if (state.gameState === undefined) {
+                return state;
+            }
+            return {
+                ...state,
+                gameState: {
+                    ...state.gameState,
+                    incomeCooldown: action.incomeCooldown,
+                }
+            }
+        }
         case 'set-field': {
             console.log("set-field", action.field);
             if (state.gameState === undefined) {
@@ -170,8 +183,11 @@ export const UiStateProvider: React.FC<React.PropsWithChildren> = ({ children })
                         dispatch({ type: 'set-field', field: action.field });
                     }
                     break;
+                case 'incomeCooldown': {
+                    dispatch({ type: 'set-incomeCooldown', incomeCooldown: action.incomeCooldown });
+                    break;
                 }
-                default: {                    
+                default: {
                     return;
                 }
             }

--- a/web/client/src/ui/Game/GameOverlay.tsx
+++ b/web/client/src/ui/Game/GameOverlay.tsx
@@ -1,4 +1,5 @@
 import { useUiState } from "@hooks";
+import { useState, useEffect } from "react";
 import { MobSlotModel, MobTypeModel } from "@models";
 
 const GameOverlay: React.FC = () => {
@@ -13,6 +14,24 @@ const GameOverlay: React.FC = () => {
     selectedTowerTypeKey,
     selectedTower,
   } = uiState;
+
+  const [incomeCooldown, setIncomeCooldown] = useState<number | undefined>(
+    uiState.gameState?.incomeCooldown
+  );
+
+  useEffect(() => {
+    setIncomeCooldown(uiState.gameState?.incomeCooldown);
+  }, [uiState.gameState?.incomeCooldown]);
+
+  useEffect(() => {
+    if (incomeCooldown === undefined) return;
+    const interval = setInterval(() => {
+      setIncomeCooldown((prev) =>
+        prev !== undefined ? Math.max(prev - 0.1, 0) : prev
+      );
+    }, 100);
+    return () => clearInterval(interval);
+  }, [incomeCooldown]);
 
   const selectedTowerType = towerTypes?.find(
     (t) => t.key === selectedTower?.type
@@ -155,6 +174,14 @@ const GameOverlay: React.FC = () => {
               <span className="ml-4 font-semibold text-right">{playerModel?.income}</span>
               <span className="font-semibold text-right">€</span>
               </div>
+            </div>
+            <div className="flex flex-row justify-between w-36">
+              <span className="font-semibold pr-5">Next in:</span>
+              <span className="ml-4 font-semibold text-right">
+                {incomeCooldown !== undefined
+                  ? incomeCooldown.toFixed(1)
+                  : '-'}s
+              </span>
             </div>
             <div className="flex flex-row justify-between w-36">
               <span className="font-semibold pr-5">Money:</span>


### PR DESCRIPTION
## Summary
- emit `incomeCooldown` events from the game when income is paid
- update GameClient and UI state hooks to handle the new event
- display a countdown timer for the next income payout in the game overlay

## Testing
- `go test ./...`
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-dev-utils/getPublicUrlOrPath')*

------
https://chatgpt.com/codex/tasks/task_e_6841cda139b88324add3538ab18379ca