### PR TITLE
Add lobby game list and observer mode

### DIFF
--- a/web/client/src/game/GameClient.ts
+++ b/web/client/src/game/GameClient.ts
@@ -165,6 +165,28 @@ export default class GameClient {
         this.webSocketClient?.disconnect();
     }
 
+    public observeGame(gameId: string) {
+        sessionStorage.removeItem('addedPlayer');
+        this.player = undefined;
+        this.webSocketClient?.disconnect();
+
+        try {
+            this.webSocketClient = new WebSocketClient(gameId, '');
+            this.webSocketClient.webSocket.onmessage = (event: MessageEvent) => {
+                const message = JSON.parse(event.data);
+                this.handleWebSocketEvent(message);
+            };
+        } catch (error) {
+            console.error(error);
+        }
+
+        ApiClient.getGameState(gameId)
+            .then(gameState => {
+                this.dispatch({ type: 'gameState', kind: 'create', gameState });
+                this.dispatch({ type: 'state', gameStatus: gameState.state });
+            }).catch(error => console.error(error));
+    }
+
     public addAgent() {
         if (this.player === undefined) {
             console.error('Cannot start game without player');

--- a/web/client/src/lib/clients/ApiClient.ts
+++ b/web/client/src/lib/clients/ApiClient.ts
@@ -1,3 +1,4 @@
+import { ServerStatusModel } from "@models";
 import { GameState, AddedPlayerModel, TowerTypeModel, MobTypeModel, SocialMediaNetworkModel } from "@models";
 import { isAbsoluteUrl } from '@helpers';
 
@@ -33,6 +34,12 @@ export default class ApiClient {
 
         return GameState.fromJSON(responseJson);
     }
+    static getServerStatus = async () => {
+        const response = await fetch(getApiUrl("status"));
+        const responseJson = await response.json();
+        return ServerStatusModel.fromJSON(responseJson);
+    }
+
 
     // Function that fetches the social media network types
     static getSocialMediaNetworks = async () => {

--- a/web/client/src/models/ServerStatusModel.ts
+++ b/web/client/src/models/ServerStatusModel.ts
@@ -1,0 +1,37 @@
+export interface GameStatusModel {
+    players: number;
+    duration: number;
+    mobsSent: number;
+    towersBuilt: number;
+}
+
+interface ServerStatusModel {
+    openGames: number;
+    runningGames: number;
+    gameStatus: { [gameId: string]: GameStatusModel };
+}
+
+namespace ServerStatusModel {
+    export function fromJSON(json: any): ServerStatusModel {
+        const gameStatus: { [gameId: string]: GameStatusModel } = {};
+        for (const key in json.gameStatus) {
+            if (Object.prototype.hasOwnProperty.call(json.gameStatus, key)) {
+                const value = json.gameStatus[key];
+                gameStatus[key] = {
+                    players: value.players,
+                    duration: value.duration,
+                    mobsSent: value.mobsSent,
+                    towersBuilt: value.towersBuilt,
+                };
+            }
+        }
+        return {
+            openGames: json.openGames,
+            runningGames: json.runningGames,
+            gameStatus,
+        };
+    }
+}
+
+export default ServerStatusModel;
+export type { GameStatusModel };

--- a/web/client/src/models/index.ts
+++ b/web/client/src/models/index.ts
@@ -14,3 +14,6 @@ export { default as BarracksModel } from './BarracksModel';
 export { default as SocialMediaNetworkModel } from './SocialMediaNetworkModel';
 export type { MobSlotModel } from './BarracksModel';
 export type { default as UiState, InitialUiState } from './UiState';
+export { default as ServerStatusModel } from './ServerStatusModel';
+
+export type { GameStatusModel } from './ServerStatusModel';

--- a/web/client/src/ui/MatchmakingPage/MatchmakingPage.tsx
+++ b/web/client/src/ui/MatchmakingPage/MatchmakingPage.tsx
@@ -1,14 +1,20 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useUiState } from "@hooks";
-import { GameState } from "@models";
+import { GameState, ServerStatusModel } from "@models";
+import ApiClient from "@clients/ApiClient";
 
 const MatchmakingPage: React.FC = () => {
     const [uiState] = useUiState();
     const { socialMediaNetworks, gameClient, gameState } = uiState;
 
+    const [status, setStatus] = useState<ServerStatusModel>();
 
     const [playerName, setPlayerName] = useState('');
     const [socialMediaNetwork, setSocialMediaNetwork] = useState('facebook');
+
+    useEffect(() => {
+        ApiClient.getServerStatus().then(setStatus).catch(console.error);
+    }, []);
 
     if (!uiState) {
         return <div>Loading...</div>;
@@ -73,8 +79,18 @@ const MatchmakingPage: React.FC = () => {
       </div> 
                 ))}
             </div>
-            <div className="rounded-md shadow">              
+            <div className="rounded-md shadow">
                 <input type="button" className="flex w-full items-center justify-center rounded-md border border-transparent bg-smw-yellow-500 px-8 py-3 text-base font-medium text-white hover:bg-smw-orange-700 md:py-4 md:px-10 md:text-lg" value="Join Game" onClick={() => uiState.gameClient.joinGame(playerName, socialMediaNetwork)} />
+            </div>
+
+            <div className="text-xl pt-6 text-smw-yellow-500"><h2>Existing Games</h2></div>
+            <div className="flex flex-col space-y-2 w-full">
+                {status && Object.entries(status.gameStatus).map(([id, gs]) => (
+                    <div key={id} className="flex flex-row justify-between items-center w-full">
+                        <span className="text-white">{gs.players} players - {gs.duration}s</span>
+                        <button className="rounded-md bg-smw-yellow-500 px-3 py-1 text-white" onClick={() => uiState.gameClient.observeGame(id)}>Observe</button>
+                    </div>
+                ))}
             </div>
             
         </div>


### PR DESCRIPTION
## Summary
- expose server status models to the client
- allow fetching server status via ApiClient
- implement `observeGame` in GameClient to watch running games
- show list of existing games in MatchmakingPage with observe buttons

## Testing
- `npm test --silent` *(fails: Cannot find module 'react-dev-utils/getPublicUrlOrPath')*

------
https://chatgpt.com/codex/tasks/task_e_6841cdd8fc1c8324b79889e9af2fa349