### PR TITLE
Rebalance mid and late towers

### DIFF
--- a/BALANCING.md
+++ b/BALANCING.md
@@ -1,0 +1,26 @@
+# Game Balancing Guide
+
+This project ships with a few helper tools to analyse balancing.
+
+## Quick simulation
+
+Run the balancer command which spawns two naive agents and records the outcome to `data.csv`:
+
+```bash
+go run ./cmd/balancer
+```
+
+The generated CSV can be plotted with your favourite tool to inspect income and unit statistics over time.
+
+## Analysing units
+
+The analyzer prints ratios for every mob type across all network configurations:
+
+```bash
+go run ./cmd/analyzer
+```
+
+Use these numbers to compare value, difficulty and income of the different units.
+
+Adjust the YAML files inside `cmd/server/networkconfigs` and the base configuration `cmd/server/gameConfig.json` to achieve a fair match up between networks.
+

--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ Currently there are four events the client can send to the server:
  `sellTower`:
 
 `{'type': 'sellTower', 'fieldId': 0, 'payload': {'towerId': 1}}`
+## Balancing the Game
+Refer to [BALANCING.md](BALANCING.md) for tips on running the built-in tools to analyze tower and mob stats.
+
 ## Deployment with Azure Container Apps
 
 1. Push images to your Azure Container Registry using the provided GitHub Actions workflow.

--- a/cmd/server/networkconfigs/facebook.yaml
+++ b/cmd/server/networkconfigs/facebook.yaml
@@ -16,9 +16,9 @@ towerTypes:
     description: "A picture so ugly your enemies will be blinded by it."
     key: "profilePicture"
     levels:
-      - level: 1  
+      - level: 1
         cost: 70
-        damage: 40
+        damage: 50
         fireRate: 1.8
         range: 5
         bulletSpeed: 11

--- a/cmd/server/networkconfigs/instagram.yaml
+++ b/cmd/server/networkconfigs/instagram.yaml
@@ -16,9 +16,9 @@ towerTypes:
     description: A word or phrase that is used to describe a picture. It's not very useful. But it reaches a lot of people.
     key: hashtag
     levels:
-      - level: 1  
+      - level: 1
         cost: 70
-        damage: 15
+        damage: 12
         fireRate: 0.4
         range: 5
         bulletSpeed: 11
@@ -30,8 +30,8 @@ towerTypes:
     levels:
       - level: 1
         cost: 550
-        damage: 100
-        fireRate: 0.2 
+        damage: 55
+        fireRate: 0.2
         range: 5
         bulletSpeed: 20
 mobTypes:

--- a/cmd/server/networkconfigs/reddit.yaml
+++ b/cmd/server/networkconfigs/reddit.yaml
@@ -18,7 +18,7 @@ towerTypes:
     levels:
       - level: 1
         cost: 70
-        damage: 40
+        damage: 50
         fireRate: 1.8
         range: 5
         bulletSpeed: 11

--- a/cmd/server/networkconfigs/twitter.yaml
+++ b/cmd/server/networkconfigs/twitter.yaml
@@ -18,7 +18,7 @@ towerTypes:
     levels:
       - level: 1
         cost: 70
-        damage: 15
+        damage: 12
         fireRate: 0.4
         range: 5
         bulletSpeed: 11
@@ -30,7 +30,7 @@ towerTypes:
     levels:
       - level: 1
         cost: 550
-        damage: 100
+        damage: 55
         fireRate: 0.2
         range: 5
         bulletSpeed: 20


### PR DESCRIPTION
## Summary
- tune tower damage to reduce huge DPS advantage of fast factions
- adjust Instagram and Twitter heavy towers to hit more balanced ratios
- small buff for Facebook and Reddit mid-tier towers

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6841cd85a0448324b6521eb0711aec4a