### PR TITLE
Limit preview build to labeled PRs

### DIFF
--- a/.github/workflows/pr_preview.yaml
+++ b/.github/workflows/pr_preview.yaml
@@ -1,13 +1,14 @@
 name: Build Preview for Pull Requests
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+  pull_request_target:
+    types: [labeled]
 
 jobs:
   golang-ci:
     name: Run Golang Linters
     runs-on: ubuntu-latest
+    if: github.event.label.name == 'preview'
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go 1.19
@@ -18,6 +19,7 @@ jobs:
   golang-test:
     name: Run Golang Unit Tests
     runs-on: ubuntu-latest
+    if: github.event.label.name == 'preview'
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go 1.19
@@ -31,6 +33,7 @@ jobs:
     name: Build Docker Images and Deploy Preview
     runs-on: ubuntu-latest
     needs: [golang-ci, golang-test]
+    if: github.event.label.name == 'preview'
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
## Summary
- only deploy PR preview when PR is labeled `preview`

## Testing
- `go test ./...`
- `golangci-lint run` *(fails: unsupported version)*

------
https://chatgpt.com/codex/tasks/task_e_6841f36f2238832497b1d8deedd0f351